### PR TITLE
Adding support for arm64

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,6 @@ jobs:
       - name: asdf_plugin_test
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v1
         with:
           command: 'saml2aws --version'

--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,19 @@ set -euo pipefail
 [[ -z ${ASDF_INSTALL_VERSION} ]] && echo "ASDF_INSTALL_VERSION is required" && exit 1
 [[ -z ${ASDF_INSTALL_PATH} ]] && echo "ASDF_INSTALL_PATH is required" && exit 1
 [[ ${ASDF_INSTALL_TYPE} != version ]] && echo "install type '${ASDF_INSTALL_TYPE}' is not supported." && exit 1
-[[ $(uname -m) != x86_64 ]] && echo "Sorry i386 (32bit arch) is not supported." && exit 1
+
+case "$(uname -m)" in
+  x86_64)
+    os_arch='amd64'
+    ;;
+  aarch64|arm64)
+    os_arch='arm64'
+    ;;
+  *)
+    echo "Sorry arch $(uname -m) is not supported."
+    exit 1
+    ;;
+esac
 
 platform="$(uname)"
 
@@ -23,7 +35,7 @@ install() {
 
   local download_url
   # Note that we're adding back the 'v' tag prefix but _only_ in the directory path, not the downloaded file name.
-  download_url="https://github.com/Versent/saml2aws/releases/download/v${version}/saml2aws_${version}_${platform}_amd64.tar.gz"
+  download_url="https://github.com/Versent/saml2aws/releases/download/v${version}/saml2aws_${version}_${platform}_${os_arch}.tar.gz"
 
   mkdir -p "${install_path}"
 


### PR DESCRIPTION
I tested in my android phone and linux machine

### Android

```shell
~ $ asdf plugin add saml2aws https://github.com/missingcharacter/asdf-saml2aws.git
~ $ cd .asdf/plugins/saml2aws/
~/.../plugins/saml2aws $ git checkout aarch64
Branch 'aarch64' set up to track remote branch 'aarch64' from 'origin'.
Switched to a new branch 'aarch64'
~/.../plugins/saml2aws $ cd -
/data/data/com.termux/files/home
~ $ asdf install saml2aws 2.32.0
Downloading saml2aws from https://github.com/Versent/saml2aws/releases/download/v2.32.0/saml2aws_2.32.0_Linux_arm64.tar.gz
~ $ ~/.asdf/installs/saml2aws/2.32.0/bin/saml2aws --version
2.32.0
~ $ file ~/.asdf/installs/saml2aws/2.32.0/bin/saml2aws
/data/data/com.termux/files/home/.asdf/installs/saml2aws/2.32.0/bin/saml2aws: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=xPvcNB5dTs2BvmIlovjQ/sBuaLUFxLfuZlaKvoodO/SLlAbVsj6bXlRpbSpCpn/leZti2HpvxYphp58PRja, stripped
~ $ uname -a
Linux localhost 4.9.248-gc4689af91bc5-ab7425221 #0 SMP PREEMPT Fri Jun 4 06:02:07 UTC 2021 aarch64 Android
```

### Linux

```shell
$ pwd
/home/user/.asdf/plugins/saml2aws
$ git remote -v
origin	https://github.com/missingcharacter/asdf-saml2aws.git (fetch)
origin	git@github.com:missingcharacter/asdf-saml2aws.git (push)
$ git branch
* aarch64
  master
$ asdf install saml2aws 2.32.0
Downloading saml2aws from https://github.com/Versent/saml2aws/releases/download/v2.32.0/saml2aws_2.32.0_Linux_amd64.tar.gz
$ ~/.asdf/installs/saml2aws/2.32.0/bin/saml2aws --version
2.32.0
$ file ~/.asdf/installs/saml2aws/2.32.0/bin/saml2aws
/home/user/.asdf/installs/saml2aws/2.32.0/bin/saml2aws: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=mQ4artL3zKDgl20ONbFr/bt7FCFFpyEs5JizKDlhI/L9KeFBAPq6JGe1rv6GO-/RONL7i1zEl3kGBTDJASo, stripped
```